### PR TITLE
Return an empty object instead of a pointer

### DIFF
--- a/templates/mutation.tmpl
+++ b/templates/mutation.tmpl
@@ -19,7 +19,7 @@ mutation {{.Function.OperationName}}({{range .Function.Args}}{{.GQLParamDef}}{{e
 	)
 
 	if err != nil {
-		return {{.Function.ReturnDeref}}v.{{.Function.GoName}}, err
+		return {{.Function.ReturnPrefix}}{{.Function.ReturnType}}{}, err
 	}
 
 	if len(v.{{.Function.GoName}}.{{.GoErrorFieldName}}) > 0 {


### PR DESCRIPTION
- Fix an issue where we try to de-reference a pointer that is nil. We now return an empty object if an error happen gathering the data for a mutation